### PR TITLE
Add keep_temp_files argument to call-methylation-state

### DIFF
--- a/methylpy/parser.py
+++ b/methylpy/parser.py
@@ -217,7 +217,8 @@ def parse_args():
                                         remove_chr_prefix=args.remove_chr_prefix,
                                         add_snp_info=args.add_snp_info,
                                         path_to_files=args.path_to_output,
-                                        min_base_quality=args.min_base_quality)
+                                        min_base_quality=args.min_base_quality,
+                                        keep_temp_files=args.keep_temp_files)
           else:
                from methylpy.call_mc_se import call_methylated_sites
                call_methylated_sites(inputf=args.input_file,


### PR DESCRIPTION
Running methylpy call-methylation-state and wanted to set --keep-temp-files True, and realized that the argument was not passed on to the function. 